### PR TITLE
Allow different JRE implementations

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/EnvisionX/kafka-debian
 
 Package: kafka
 Architecture: all
-Depends: openjdk-8-jre-headless, logrotate, cron
+Depends: java8-runtime-headless, logrotate, cron
 Suggests: zookeeperd
 Description: Distributed, partitioned, replicated commit log service.
  Kafka is a distributed, partitioned, replicated commit log service.


### PR DESCRIPTION
Replace the `openjdk-8-jre-headless` dependency with
`java8-runtime-headless` so you can use the Oracle JVM
or maybe your own implementation.